### PR TITLE
Min max usage

### DIFF
--- a/rat_utils.py
+++ b/rat_utils.py
@@ -335,7 +335,9 @@ def rat_classify(raster_layer, band, rat, criteria, ramp=None, feedback=QgsRaste
             ramp.setTotalColorCount(len(unique_labels))
             i = 0
             for index in unique_indexes:
-                label_colors[labels[index-1]] = ramp.color(i)
+                if Qgis.QGIS_VERSION_INT >= 31803:
+                    index -= 1
+                label_colors[labels[index]] = ramp.color(i)
                 i += 1
 
         # Create values for the ramp

--- a/rat_utils.py
+++ b/rat_utils.py
@@ -335,7 +335,7 @@ def rat_classify(raster_layer, band, rat, criteria, ramp=None, feedback=QgsRaste
             ramp.setTotalColorCount(len(unique_labels))
             i = 0
             for index in unique_indexes:
-                label_colors[labels[index]] = ramp.color(ramp.value(i))
+                label_colors[labels[index-1]] = ramp.color(i)
                 i += 1
 
         # Create values for the ramp


### PR DESCRIPTION
We have a raster band where we are not using whole numbers where we could. We are doing this in order to get the most amount of values available by utilizing the maximum amount of memory space in a float32. In the Raster Attribute Table, we opted to use GFU_Min and GFU_Max usage columns to avoid issues of precision.

When using the classify button in the Raster Attribute Table in QGIS, I got the following index error on QGIS versions 3.18.3 and 3.24.3

```
line 338, in rat_classify
    label_colors[labels[index]] = ramp.color(i)
IndexError: list index out of range
```

To replicate the error, we created a crude test geotiff named RAT_with_float.tiff that is in tests/data
in 3.16.5 unique_indexes returned ```[0, 1, 2, 3, 4, 5, 6, 7]```
in 3.18.3 unique_indexes returned ```[1, 2, 3, 4, 5, 6, 7, 8]```

Also we found ramp.value(i) was returning 0 for all the i values. This may be expected in the context of how GFU_Min and GFU_Max are typically used? We changed it to input i directly and it worked more to our expectations.

I hadn't looked through these issues thoroughly but these changes seem to get us to where we wanted although I'm sure there are other considerations being missed on my part.